### PR TITLE
Bugfix - Fixed hiding with acceptance & difficulty

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,6 +10,9 @@ $(document).ready(function () {
 	$('tbody.reactable-data td:nth-child(6)').each((index, obj) => {
   		$(obj).css('opacity', '0');
 	});
+	
+	// Hide question stats while on the problem's page
+	$('.question-info').hide();
    
    	// @TODO is this depricated?
 	$('.header-ac').hide();

--- a/background.js
+++ b/background.js
@@ -1,9 +1,19 @@
 
 $(document).ready(function () {
+	
+	// Hide acceptance
+	$('tbody.reactable-data td:nth-child(5)').each((index, obj) => {
+  		$(obj).css('opacity', '0');
+	});
+	
+	// Hide difficulty
+	$('tbody.reactable-data td:nth-child(6)').each((index, obj) => {
+  		$(obj).css('opacity', '0');
+	});
    
+   	// @TODO is this depricated?
 	$('.header-ac').hide();
 	$('.header-level').hide();
-
 	$("#problemList td:nth-child(4)").hide();
 	$("#problemList td:nth-child(7)").hide();
 	$("#question_list th:nth-child(4)").text("");
@@ -18,25 +28,23 @@ $(document).ready(function () {
 
 	$("#result").watch({
 		properties: "prop_innerHTML",
-    	watchChildren: true,
-    	callback: function (data, i) {
-    		var count = (data.vals[i].match(/class="ng-binding text-success"/g) || []).length;
-        	if (count >= 0) {
-        		$("#result-state").css('display','inline-block');
-        		
-        	}
-        	if (count == 1) {
-        		info.insertAfter($("#result-state").parent());
-        		info.show();
-        	}
-    	}
+    		watchChildren: true,
+    		callback: function (data, i) {
+    			var count = (data.vals[i].match(/class="ng-binding text-success"/g) || []).length;
+        		if (count >= 0) {
+        			$("#result-state").css('display','inline-block');
+        		}
+        		if (count == 1) {
+        			info.insertAfter($("#result-state").parent());
+        			info.show();
+        		}
+    		}
 	});
 
 	chrome.storage.sync.get('hideLocked', function(response) {
-		if (response.hideLocked)
+		if (response.hideLocked) {
 			$('tr i.fa.fa-lock').parent().parent().remove();
+		}
 	});
-
-
 });
 


### PR DESCRIPTION
I noticed recently that this extension stopped working for me - I'm assuming that the site was updated or something.

This PR now hides the acceptance and difficulty columns on the main page, as well as the question stats while you're inside the context of solving a problem.
